### PR TITLE
Sort by guide compatibility in search.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'rack-attack'
 gem 'impressionist', '~> 1.5.0'
 gem 'rack-cors', require: 'rack/cors'
 gem 'delayed_job_mongoid'
+gem 'activejob_backport'
 gem 'patron' # For searchKick
 gem 'searchkick', '~> 0.8.5'
 gem 'pundit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       rack-test (~> 0.6.2)
     active_model_serializers (0.9.3)
       activemodel (>= 3.2)
+    activejob_backport (0.0.3)
+      activesupport (>= 4.0.0)
     activemodel (4.0.2)
       activesupport (= 4.0.2)
       builder (~> 3.1.0)
@@ -239,8 +241,8 @@ GEM
       rails-assets-angular (~> 1.0)
       rails-assets-jquery-ui
     rails-assets-jquery (2.1.3)
-    rails-assets-jquery-ui (1.11.2)
-      rails-assets-jquery (>= 1.6)
+    rails-assets-jquery-ui (1.11.3)
+      rails-assets-jquery (>= 1.7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -363,6 +365,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  activejob_backport
   aws-sdk (~> 1.55.0)
   bcrypt
   better_errors

--- a/app/controllers/crop_searches_controller.rb
+++ b/app/controllers/crop_searches_controller.rb
@@ -11,17 +11,31 @@ class CropSearchesController < ApplicationController
                                   'common_names^10',
                                   'binomial_name^10',
                                   'description'],
-                         boost_by: [:guides_count]
-                         )
+                                  boost_by: [:guides_count]
+                        )
     if query.empty?
       @crops = Crop.search('*', limit: 25, boost_by: [:guides_count])
     end
 
     # Use the crop results to look-up guides
     crop_ids = @crops.map { |crop| crop.id }
-    @guides = Guide.search('*',
-                           where: { crop_id: crop_ids })
+
+    @guides = Guide.search('*', where: {crop_id: crop_ids}, order: guide_order)
 
     render :show
+  end
+
+  protected
+  def guide_order
+    # Default order for logged out user.
+    return {_score: :desc} unless current_user
+
+    {
+      'compatibilities.score' => {
+        order: 'desc', nested_filter: {
+          term: { 'compatibilities.user_id' => current_user.id.to_s }
+        }
+      }
+    }
   end
 end

--- a/app/jobs/reindex_guides_job.rb
+++ b/app/jobs/reindex_guides_job.rb
@@ -1,0 +1,7 @@
+class ReindexGuidesJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    Guide.reindex
+  end
+end

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -4,6 +4,8 @@ class Garden
   belongs_to :user
   validates_presence_of :user
 
+  after_save :reindex_guides
+
   embeds_many :garden_crops
 
   field :name
@@ -21,4 +23,9 @@ class Garden
   accepts_nested_attributes_for :pictures
 
   scope :is_public, -> { where(is_private: true) }
+
+  protected
+  def reindex_guides
+    ReindexGuidesJob.perform_later
+  end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -2,7 +2,19 @@ class Guide
   include Mongoid::Document
   include Mongoid::Paperclip
   include Mongoid::Slug
-  searchkick
+  searchkick callbacks: :async, merge_mappings: true, mappings: {
+    guide: {
+      properties: {
+        compatibilities: {
+          type: 'nested',
+          properties: {
+            user_id: {type: "string"},
+            score: {type: "integer"}
+          }
+        }
+      }
+    }
+  }
 
   is_impressionable counter_cache: true,
                     column_name: :impressions_field,
@@ -45,7 +57,24 @@ class Guide
   end
 
   def search_data
-    as_json only: [:name, :overview, :crop_id]
+    {
+      name: name,
+      overview: overview,
+      crop_id: crop_id,
+      compatibilities: compatibilities
+    }
+  end
+
+  def compatibilities
+    return @compatibilities if defined?(@compatibilities)
+
+    @compatibilities = []
+
+    User.each do |user|
+      @compatibilities << {user_id: user.id.to_s, score: compatibility_score(user).to_i}
+    end
+
+    @compatibilities
   end
 
   def basic_needs(current_user)

--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,1 @@
+ActiveJob::Base.queue_adapter = :delayed_job

--- a/spec/jobs/reindex_guides_job_spec.rb
+++ b/spec/jobs/reindex_guides_job_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe ReindexGuidesJob do
+  it 'reindexes guides' do
+    expect(Guide).to receive(:reindex)
+
+    ReindexGuidesJob.new.perform
+  end
+end

--- a/spec/models/garden_crop_spec.rb
+++ b/spec/models/garden_crop_spec.rb
@@ -12,4 +12,10 @@ describe GardenCrop do
     expect(gc.garden.id).to eq(garden.id)
     expect(gc.persisted?).to eq(true)
   end
+
+  it 'reindexes guides' do
+    expect(Guide).to receive(:reindex)
+
+    FactoryGirl.create(:garden, user: FactoryGirl.create(:user))
+  end
 end


### PR DESCRIPTION
In order to do this, we need to move guide reindexing to Delayed Job
because each indexed guide contains the compatibility scores of all
users.

Resolves #438
